### PR TITLE
Proxy headers now also take a function

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -126,8 +126,13 @@ function injectAuthHeader(req) {
 // along with the x-forwarded-for, x-forwarded-port, and via headers
 function injectProxyHeaders(req, rule){
   // inject any custom headers as configured
-  config.headers.forEach(function(header){
-    req.headers[header.name] = header.value;
+  config.headers.forEach(function(header) {
+    if(typeof(header.value) == 'function') {
+      req.headers[header.name] = header.value.call(undefined, req);
+    }
+    else {
+      req.headers[header.name] = header.value;
+    }
   });
 
   injectAuthHeader(req);


### PR DESCRIPTION
Use it like this:

```
'Authorization': function(req) {
  accessToken = (req.user && req.user.access_token) ? req.user.access_token : 'api_token'
  return 'Bearer '.concat(accessToken)
}
```
