### PR TITLE
Ensure "host" header is set properly

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -281,6 +281,7 @@ function parseTargetServer(value) {
     host: target.hostname,
     // inject a default port if one wasn't specified
     port: target.port || ((target.protocol === 'https:') ? 443 : 80),
+    originalPort: target.port,
     protocol: target.protocol,
     path: path
   };

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -126,7 +126,7 @@ function injectAuthHeader(req) {
 // along with the x-forwarded-for, x-forwarded-port, and via headers
 function injectProxyHeaders(req, rule){
   // the HTTP host header is often needed by the target webserver config
-  req.headers['host'] = rule.target.host;
+  req.headers['host'] = rule.target.host + (rule.target.originalPort ? util.format(':%d', rule.target.originalPort) : '');
   // document that this request was proxied
   req.headers['via'] =  util.format('http://%s:%s', req.connection.address().address, req.connection.address().port);
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -125,6 +125,11 @@ function injectAuthHeader(req) {
 // inject any custom header values into a proxy request
 // along with the x-forwarded-for, x-forwarded-port, and via headers
 function injectProxyHeaders(req, rule){
+  // the HTTP host header is often needed by the target webserver config
+  req.headers['host'] = rule.target.host;
+  // document that this request was proxied
+  req.headers['via'] =  util.format('http://%s:%s', req.connection.address().address, req.connection.address().port);
+
   // inject any custom headers as configured
   config.headers.forEach(function(header) {
     var value = header.value;
@@ -143,9 +148,4 @@ function injectProxyHeaders(req, rule){
   });
 
   injectAuthHeader(req);
-
-  // the HTTP host header is often needed by the target webserver config
-  req.headers['host'] = rule.target.host;
-  // document that this request was proxied
-  req.headers['via'] =  util.format('http://%s:%s', req.connection.address().address, req.connection.address().port);
 }


### PR DESCRIPTION
There are two changes here:

### Allow overriding all headers

The first change here is setting the `host` and `via` headers before the user-configured headers, allowing the user to override them as necessary. For my case this is required, because I have yet another proxy in between my local machine and the end API (an SSH tunnel that is required to bypass a VPN requirement), and the API I'm hitting uses the provided `host` to build out absolute URLs (that's probably not a good idea on their end, but actually works in my favor in this case).

### Set host port if non-standard

The second change (appending the port to `req.headers['host']`) ensures that if there was a port on the original target URL, it is retained instead of dropped. The `originalPort` code is there so as not to append 80/443 if they weren't there to begin with (since `target.port` is forcibly set to those).  

I wanted to create tests for this second change, but it's a pretty big addition to your testing setup and I couldn't figure out how to make it work. (You'd need tests at the nock level to ensure they're getting the proper headers in a request.)