### PR TITLE
make sure res.status is a function before we call it

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -66,7 +66,9 @@ function proxyRequest(req, res, rule) {
     }
 
     logger.error('proxy: error - %s %s - %s', proxyRequest.method, proxyRequest.url, err.message);
-    res.status(status).json({ error: status, message: err.message });
+    if( res.status && typeof res.status === 'function'  ){
+        res.status(status).json({ error: status, message: err.message });
+    }
   };
 
   // get a ProxyServer from the cache


### PR DESCRIPTION
Sometimes, I get an error where res.status is undefined. Trying to call it throws an error, and crashes.
This PR just checks to make sure res.status exists and is a function before trying to call it.