### PR TITLE
Replace deprecated function for compatibility Node 12.x

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -31,7 +31,7 @@ function format(color, messages) {
 }
 
 exports.banner = function banner() {
-  util.puts([
+  console.log([
     '',
     ' #####  ####   ####  #    #       #####  #####   ####  #    # #   #',
     '   #   #      #    # ##   #       #    # #    # #    #  #  #   # # ',


### PR DESCRIPTION
The function "util.puts" is deprecated in Node 10.x and removed in Node 12.x.

For run in Node 12.x and higher, replace function "util.puts" by "console.log"